### PR TITLE
Add api usage example

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -1,0 +1,97 @@
+/******************************************************************************
+* Description: Example interation with our API. How to use libcurl taken from
+*   source directly. Not to be called from the main program!
+* Programmers: Gabriel Frey freyg@purdue.edu
+* Source:      https://curl.se/libcurl/c/http-post.html
+* Required Op: -lcurl
+******************************************************************************/
+
+/* to complie use:
+* gcc api-test.c -lcurl -o api-test
+*/
+
+// Includes
+#include <stdio.h>
+#include <curl/curl.h>
+
+void addScore();
+void getScores();
+
+int main(void){
+  addScore();
+  getScores();
+
+  return 0;
+}
+
+/******************************************************************************
+* Function:    addScore
+* Description: Example of curl calls to add player score
+* Parameters:
+* Return:      void
+******************************************************************************/
+void addScore(){
+  CURL *curl;
+  CURLcode res;
+
+  /* In windows, this will init the winsock stuff */
+  curl_global_init(CURL_GLOBAL_ALL);
+
+  /* get a curl handle */
+  curl = curl_easy_init();
+  if (curl){
+    /* First set the URL that is about to receive our POST. This URL can
+       just as well be a https:// URL if that is what should receive the
+       data. */
+    curl_easy_setopt(curl, CURLOPT_URL, "http://frey.network/CNIT315/api.php");
+    /* Now specify the POST data */
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "player_name=daniel&score=1000&seed=1&version=0.01");
+
+    /* Perform the request, res will get the return code */
+    res = curl_easy_perform(curl);
+    /* Check for errors */
+    if (res != CURLE_OK)
+      fprintf(stderr, "curl_easy_perform() failed: %s\n",
+              curl_easy_strerror(res));
+
+    /* always cleanup */
+    curl_easy_cleanup(curl);
+  }
+  curl_global_cleanup();
+}
+
+/******************************************************************************
+* Function:    getScores
+* Description: Example of how to get scores from API
+* Parameters:
+* Return:      void
+******************************************************************************/
+void getScores(){
+  CURL *curl;
+  CURLcode res;
+
+  /* In windows, this will init the winsock stuff */
+  curl_global_init(CURL_GLOBAL_ALL);
+
+  /* get a curl handle */
+  curl = curl_easy_init();
+  if (curl){
+    /* First set the URL that is about to receive our POST. This URL can
+       just as well be a https:// URL if that is what should receive the
+       data. */
+    curl_easy_setopt(curl, CURLOPT_URL, "http://frey.network/CNIT315/api.php");
+    /* Now specify the POST data */
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "seed=1&version=0.01");
+
+    /* Perform the request, res will get the return code */
+    res = curl_easy_perform(curl);
+    /* Check for errors */
+    if (res != CURLE_OK)
+      fprintf(stderr, "curl_easy_perform() failed: %s\n",
+              curl_easy_strerror(res));
+
+    /* always cleanup */
+    curl_easy_cleanup(curl);
+  }
+  curl_global_cleanup();
+}

--- a/api.php
+++ b/api.php
@@ -1,0 +1,83 @@
+<?php
+//Includes
+
+//source - https://www.benmarshall.me/php-mysql-connect/
+
+define('DB_SERVER', 'localhost');
+define('DB_USERNAME', 'gabriel');
+define('DB_PASSWORD', 'supersecureplaintext');
+
+// get values from form
+if (isset($_POST['player_name'])){
+  $player_name = $_POST['player_name'];
+  $score = $_POST['score'];
+}
+if (isset($_POST['seed'])){
+  $seed = $_POST['seed'];
+  $version = $_POST['version'];
+}
+else{
+    // defualts to allow access from a browser
+    $seed = 1;
+    $version = 0.01;
+}
+
+// always wrap PDO operations in a try/catch
+try{
+  // only make a connection when it is needed
+  // no guarantee of a future request
+  $conn = new PDO('mysql:host=localhost; dbname=class', DB_USERNAME, DB_PASSWORD);
+  $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+  // ensure that database is setup
+  if (!sql_table_exists($conn, 'score')){
+    $stmt = $conn->prepare('CREATE TABLE score (id INT NOT NULL AUTO_INCREMENT, player_name VARCHAR(80) NOT NULL, score INT NOT NULL, seed INT, version DECIMAL(6,4), played DATE, PRIMARY KEY (id));');
+    $stmt->execute();
+    echo "Created score table successfully!\n";
+  }
+
+  if (isset($player_name)){
+    // player was given, so assume to add a score
+    sql_add_score($conn, $player_name, $score, $seed, $version);
+    echo "Added new score! $player_name, $score, $seed, $version\n";
+  }
+  else{
+    // no details given, so assume request to get highscores
+    sql_echo_scores($conn, $seed, $version);
+  }
+}
+catch(PDOException $e){
+  echo 'ERROR: ' . $e->getMessage();
+}
+
+// Functions
+function sql_table_exists($conn, $name){
+  // cannot use a prepare statement, because that always adds ''
+  // Caution! should only be used internally
+  try{
+    $result = $conn->query("DESCRIBE `$name`");
+  }
+  catch(PDOException $e){
+    return false;
+  }
+
+  return $result !== false;
+}
+
+function sql_add_score($conn, $player_name, $score, $seed, $version){
+  $stmt = $conn->prepare('INSERT INTO score (player_name, score, seed, version, played) VALUES (:player_name, :score, :seed, :version, CURDATE())');
+  $stmt->execute(array(':player_name' => $player_name, ':score' => $score, ':seed' => $seed, ':version' => $version));
+}
+
+function sql_echo_scores($conn, $seed, $version){
+  $stmt = $conn->prepare('SELECT player_name, score FROM score WHERE seed = :seed AND version = :version');
+  $stmt->execute(array(':seed' => $seed, ':version' => $version));
+
+  // get array with all result rows
+  $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+  foreach ($rows as $row){
+    echo $row["player_name"] . " " . $row["score"] . "\n";
+  }
+}
+?>


### PR DESCRIPTION
Included PHP file used on the server to interact directly with the SQL database. This PHP file is for reference only! Changes on it will have no affect. `api-test` is derived from online example: https://curl.se/libcurl/c/http-post.html, see license there.

In order to compile the `api-test.c` file add `-lcurl` to the `gcc` compile options. Ex. `gcc api-test.c -lcurl -o api`
